### PR TITLE
44.0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -32,7 +32,7 @@ parts:
   gnome-characters:
     source: https://gitlab.gnome.org/GNOME/gnome-characters.git
     source-type: git
-    source-tag: '42.0'
+    source-tag: '44.0'
     plugin: meson
     meson-parameters:
       - --buildtype=release


### PR DESCRIPTION
# Pull Request Template

## Description

GNOME Characters 42 -> 44 is a major improvement. The older version of Characters was stuck with a very old set of emoji. The new version supports all the latest emoji up to Unicode 15 and supports composite emoji (like gender, skin tone, country flags, etc.)

Fixes # (issue)

## Type of change

Please check only the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested on Ubuntu 23.04 and Ubuntu 20.04 LTS.

The newest emoji (such as moose & jellyfish) display in the app but do not display correctly in other apps. That is expected and not really a bug in the Characters app or something that should prevent this update from being released.

**Test Configuration**:

* OS (please include version):
* Any other relevant environment information:

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings