### PR TITLE
Update to 48.0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -32,11 +32,11 @@ parts:
   gnome-characters:
     source: https://gitlab.gnome.org/GNOME/gnome-characters.git
     source-type: git
-    source-tag: '46.0'
+    source-tag: '48.0'
     source-depth: 1
 # ext:updatesnap
 #   version-format:
-#     lower-than: '47'
+#     lower-than: '49'
 #     no-9x-revisions: true
     plugin: meson
     meson-parameters:


### PR DESCRIPTION
The new version builds and runs without issue locally. Upstream meson requirements updated the glib depends and moved from libhandy to libadwaita, those libraries and versions are available in the 46 sdk
